### PR TITLE
Destroy function & few bug fixes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject exoscale/exoscale "0.1.1"
+(defproject exoscale/exoscale "0.1.2"
   :description "All things Exoscale, in Clojure"
   :url "https://github.com/exoscale/clojure-exoscale"
   :plugins [[lein-kibit      "0.1.6"]

--- a/src/exoscale/compute/api/http.clj
+++ b/src/exoscale/compute/api/http.clj
@@ -1,10 +1,9 @@
 (ns exoscale.compute.api.http
   "HTTP support for the Exoscale Compute API"
   (:require [clojure.string               :as str]
-            [cheshire.core                :as json]
             [aleph.http                   :as http]
             [manifold.deferred            :as d]
-            [byte-streams                 :as bs]
+            [manifold.time                :as t]
             [exoscale.compute.api.payload :as payload]))
 
 (def default-page-size
@@ -117,7 +116,7 @@
   (let [interval (or (:poll-interval config) default-poll-interval)]
     (fn [{:keys [jobstatus] :as job}]
       (if (zero? jobstatus)
-        (d/chain (d/future (Thread/sleep interval))
+        (d/chain (t/in interval (constantly nil))
                  (fn [_] (d/recur (dec remaining))))
         (job-result opcode job)))))
 

--- a/src/exoscale/compute/api/http.clj
+++ b/src/exoscale/compute/api/http.clj
@@ -125,10 +125,12 @@
   (fn [{:keys [jobid] :as resp}]
     (if (some? jobid)
       (d/loop [remaining (or (:max-polls config) default-max-polls)]
-        ;; The previous response can be used as input
-        ;; to queryAsyncJobResult directly
-        (d/chain (json-request!! config "queryAsyncJobResult" resp)
-                 (wait-or-return-job!! config remaining opcode)))
+        (if (pos? remaining)
+          ;; The previous response can be used as input
+          ;; to queryAsyncJobResult directly
+          (d/chain (json-request!! config "queryAsyncJobResult" resp)
+                   (wait-or-return-job!! config remaining opcode))
+          resp))
       resp)))
 
 (defn job-request!!

--- a/src/exoscale/compute/api/vm.clj
+++ b/src/exoscale/compute/api/vm.clj
@@ -165,6 +165,13 @@
            (fn [params] (client/api-call config :deploy-virtual-machine params))
            sanitize-vm))
 
+(defn destroy
+  "Destroy virtual machine"
+  [config target]
+  (d/chain (resolve-id config target)
+           #(client/api-call config :destroy-virtual-machine {:id %})
+           (constantly nil)))
+
 (defn ssh
   "Asynchronously reach out to a machine to execute an ssh command"
   [config target command]
@@ -231,5 +238,6 @@
 
   @(ssh config :clojure01 "echo hello")
   @(stop config :clojure01)
-
+  
+  @(destroy config :clojure01)
   )


### PR DESCRIPTION
This PR adds a `destroy` function to, as its name says, destroy a virtual machine.

Meanwhile, it also fixes or enhances few other things:
* `max-polls` parameter is correctly handled;
* `(d/future (Thread/sleep ...))` is replaced by `manifold.time/in` to avoid acquiring a thread to block it;
* `sanitize-vm` handles edge cases, mainly when resolution of async job fails or when `max-polls` is set to 0.