### PR TITLE
Release 0.1.3 - fix regression, add timeouts and expose created field

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject exoscale/exoscale "0.1.2"
+(defproject exoscale/exoscale "0.1.3"
   :description "All things Exoscale, in Clojure"
   :url "https://github.com/exoscale/clojure-exoscale"
   :plugins [[lein-kibit      "0.1.6"]

--- a/src/exoscale/compute/api/http.clj
+++ b/src/exoscale/compute/api/http.clj
@@ -22,6 +22,12 @@
   "Default HTTP endpoint for the Exoscale API"
   "https://api.exoscale.com/compute")
 
+(def default-http-opts
+  "Default HTTP options passed to the underlying HTTP library (aleph)."
+  {:connection-timeout 10000
+   :request-timeout    10000
+   :read-timeout       10000})
+
 (def entity-special-cases
   {"resetPasswordForVirtualMachine"  [:reset-password :virtualmachine]
    "changeServiceForVirtualMachine"  [:change-service :virtualmachine]
@@ -54,7 +60,7 @@
 (defn raw-request!!
   "Send an HTTP request with manifold"
   [{:keys [endpoint http-opts] :as config} payload]
-  (let [opts   (merge http-opts {:as :json})
+  (let [opts   (merge default-http-opts http-opts {:as :json})
         method (some-> config :request-method name str/lower-case keyword)
         reqfn  (if (= :get method) http/get http/post)
         paramk (if (= :get method) :query-params :form-params)]

--- a/src/exoscale/compute/api/vm.clj
+++ b/src/exoscale/compute/api/vm.clj
@@ -62,7 +62,7 @@
   "Coerce API response into something a bit more useful"
   [resp]
   (cond
-    (contains? resp :jobstatus)
+    (and (contains? resp :state) (not (nil? (:state resp))))
     (let [tag-acc #(assoc %1 (keyword (:key %2)) (:value %2))]
       (-> (select-keys resp [:id :name :displayname :keypair :memory
                              :cpunumber :group :password])
@@ -76,6 +76,7 @@
           (assoc :affinity-groups (mapv sanitize-ag (:affinitygroup resp)))
           (assoc :public (sanitize-public (:nic resp)))
           (assoc :nics (sanitize-nics (:nic resp)))
+          (assoc :created (:created resp))
           (meta/describe :exsocale.compute/vm resp)))
 
     (contains? resp :id)


### PR DESCRIPTION
- Fix a regression in the `sanitize-vm` function. `jobstatus` is not present when VM has no running job.
- Add default resonable timeouts used for each http request
- Extract the `created` field in `sanitize-vm`