### PR TITLE
0.1.4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject exoscale/exoscale "0.1.3"
+(defproject exoscale/exoscale "0.1.4"
   :description "All things Exoscale, in Clojure"
   :url "https://github.com/exoscale/clojure-exoscale"
   :plugins [[lein-kibit      "0.1.6"]

--- a/src/exoscale/compute/api/payload.clj
+++ b/src/exoscale/compute/api/payload.clj
@@ -36,7 +36,7 @@
         (transform-maps (name k) v)
 
         (sequential? v)
-        (map-indexed #([k (if (keyword? %) (name %) (str %))]) v)
+        (map #(vector k (if (keyword? %) (name %) (str %))) v)
 
         :else
         [[k (str v)]]))))

--- a/src/exoscale/compute/api/payload.clj
+++ b/src/exoscale/compute/api/payload.clj
@@ -36,7 +36,7 @@
         (transform-maps (name k) v)
 
         (sequential? v)
-        [[k (str/join "," (map name v))]]
+        (map-indexed #([k (if (keyword? %) (name %) (str %))]) v)
 
         :else
         [[k (str v)]]))))

--- a/src/exoscale/compute/api/spec.clj
+++ b/src/exoscale/compute/api/spec.clj
@@ -9,6 +9,8 @@
 (spec/def :tmpl/template         string?)
 (spec/def :sg/securitygroupids   (spec/coll-of uuid?))
 (spec/def :sg/securitygroupnames (spec/coll-of string?))
+(spec/def :ag/affinitygroupids   (spec/coll-of uuid?))
+(spec/def :ag/affinitygroupnames (spec/coll-of string?))
 (spec/def :vm/name               string?)
 (spec/def :vm/displayname        string?)
 (spec/def :vm/group              string?)
@@ -18,6 +20,7 @@
 (spec/def :vm/startvm            boolean?)
 (spec/def :vm/userdata           string?)
 (spec/def :vm/keypair            string?)
+(spec/def :vm/networkids         (spec/coll-of uuid?))
 
 (spec/def :vm/forced?            boolean?)
 
@@ -33,6 +36,8 @@
                       (or :zone/zoneid :zone/zone)]
              :opt-un [:sg/securitygroupids
                       :sg/securitygroupnames
+                      :ag/affinitygroupids
+                      :ag/affinitygroupnames
                       :vm/displayname
                       :vm/group
                       :vm/ip4
@@ -41,7 +46,8 @@
                       :vm/name
                       :vm/rootdisksize
                       :vm/startvm
-                      :vm/userdata]))
+                      :vm/userdata
+                      :vm/networkids]))
 
 (spec/def :exoscale.compute/vm
   (spec/or :uuid uuid?

--- a/src/exoscale/compute/api/vm.clj
+++ b/src/exoscale/compute/api/vm.clj
@@ -166,40 +166,12 @@
       (some? serviceoffering) (assoc :serviceofferingid sid)
       (some? template) (assoc :templateid tid))))
 
-(defn serialize-list
-  "Serialize the list in a coma separated list"
-  [v]
-  (str/join "," (map #(if (keyword? %) (name %) (str %)) v)))
-
-(defn sanitize-params
-  "CS expects list serialized as coma separated list of string. Aleph
-  explodes list into individual key-value pairs."
-  [{:keys [securitygroupids securitygroupnames affinitygroupids
-           affinitygroupnames networkids]
-    :as   params}]
-  (cond-> params
-    (some? securitygroupids)
-    (assoc :securitygroupids (serialize-list securitygroupids))
-
-    (some? securitygroupnames)
-    (assoc :securitygroupnames (serialize-list securitygroupnames))
-
-    (some? affinitygroupids)
-    (assoc :affinitygroupids (serialize-list affinitygroupids))
-
-    (some? affinitygroupnames)
-    (assoc :affinitygroupnames (serialize-list affinitygroupnames))
-
-    (some? networkids)
-    (assoc :networkids (serialize-list networkids))))
-
 (defn deploy
   "Deploy virtual machine"
   [config params]
   {:pre [(spec/valid? :exoscale.compute/vm params)]}
   (d/chain (resolve-indirect-params config params)
            (fn [resolved] (merge resolved (dissoc params :zone :template :serviceoffering)))
-           sanitize-params
            (fn [params] (client/api-call config :deploy-virtual-machine params))
            sanitize-vm))
 


### PR DESCRIPTION
Changelog:
* Fix the signature to use the same serialisation mechanism used by Aleph to avoid differences between the params used for the signature and the params put in the body.
* Sanitise the params before sending them out to the underlying http bits.
* Extend the specs for the VM's params.