### PR TITLE
Decode http error body as string

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
   :codox {:source-uri  "https://github.com/exoscale/clojure-exoscale/blob/{version}/{filepath}#L{line}"
           :doc-files   ["doc/intro.md"]
           :metadata    {:doc/format :markdown}}
-  :dependencies [[org.clojure/clojure "1.9.0"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
                  [cheshire            "5.8.1"]
                  [clj-time            "0.15.1"]
                  [aleph               "0.4.6"]


### PR DESCRIPTION
This will decode the response body as string from the ex-info.ex-data.body when we have one, otherwise it will just rethrow.

This makes it easier to understand what/why request fail, right now we only have the headers and the status.

This also bumps the clojure dependency.