### PR TITLE
Fix polling an async job

### DIFF
--- a/src/exoscale/compute/api/http.clj
+++ b/src/exoscale/compute/api/http.clj
@@ -133,7 +133,7 @@
         (if (pos? remaining)
           ;; The previous response can be used as input
           ;; to queryAsyncJobResult directly
-          (d/chain (json-request!! config "queryAsyncJobResult" resp)
+          (d/chain (json-request!! config "queryAsyncJobResult" {:jobid jobid})
                    (wait-or-return-job!! config remaining opcode))
           resp))
       resp)))


### PR DESCRIPTION
This PR fixes a bug I found recently. Without changes, we pass the whole job map into params to the next request which leads to the wrong signature. Tested locally with pre-prod in repl.

