### PR TITLE
ensure that we deal with get* calls the same way as list* calls

### DIFF
--- a/src/exoscale/compute/api/http.clj
+++ b/src/exoscale/compute/api/http.clj
@@ -50,7 +50,11 @@
 (def list-command?
   (memoize
    (fn [opcode]
-     (-> opcode name (str/starts-with? "list")))))
+     (let [opcode (name opcode)]
+       (or (str/starts-with? opcode "list")
+           ;; we need to make sure we deal with get* calls the same
+           ;; way as for lists (ex for getInstancePool)
+           (str/starts-with? opcode "get"))))))
 
 (defn opts->http-request-opts
   "Converts legacy request opts to jdk11 client opts"
@@ -92,7 +96,6 @@
 (defn find-payload
   [resp opcode]
   (let [list?      (list-command? opcode)
-        ks         (set (keys resp))
         payload    (-> resp (dissoc :count) vals first)
         elem-count (:count resp)]
     (cond

--- a/test/exoscale/compute/api/http_test.clj
+++ b/test/exoscale/compute/api/http_test.clj
@@ -206,3 +206,16 @@
             (is (= 431 status))
             (is (= error-resp
                    (json/parse-string body true)))))))))
+
+(deftest direct-non-list-response
+  (let [payload {:id "yolo" :name "ipool"}]
+    (utils/with-server 8080 {:getInstancePool (constantly {:status 200
+                                                           :body {:getinstancepoolresponse
+                                                                  {:count 1
+                                                                   :instancepool [payload]}}})}
+      (is (= [payload]
+             (deref (http/request!! {:endpoint "http://localhost:8080"
+                                     :api-key "foo"
+                                     :api-secret "bar"}
+                                    "getInstancePool"
+                                    payload)))))))


### PR DESCRIPTION
With the introduction of 6481d05175e0c660aea145fb8f9bf3cb8132d608 non
list calls were assumed to always return a jobresult, but this is not
a valid assumption for non CS calls we implemented such as
getInstancePool, they would then return nil on success. 
In that case we will now consider them as list calls matching the behavior pre 6481d05175e0c660aea145fb8f9bf3cb8132d608