### PR TITLE
read body with timeout

### DIFF
--- a/src/exoscale/compute/api/http.clj
+++ b/src/exoscale/compute/api/http.clj
@@ -72,7 +72,7 @@
   manually close the inputstream after `timeout` (or upon errors)"
   [^InputStream input-stream timeout executor]
   (when input-stream
-    (with-open [rdr (io/reader is)]
+    (with-open [rdr (io/reader input-stream)]
       (let [f (auspex/future (fn [] (json/parse-stream rdr true))
                              executor)
             json-body (deref f timeout ::timeout)]

--- a/src/exoscale/compute/api/http.clj
+++ b/src/exoscale/compute/api/http.clj
@@ -72,12 +72,12 @@
   manually close the inputstream after `timeout` (or upon errors)"
   [^InputStream input-stream timeout executor]
   (when input-stream
-    (with-open [is input-stream
-                rdr (io/reader is)]
+    (with-open [rdr (io/reader is)]
       (let [f (auspex/future (fn [] (json/parse-stream rdr true))
                              executor)
             json-body (deref f timeout ::timeout)]
         (when (= ::timeout json-body)
+          (.close input-stream)
           (throw (ex-info "Timeout while reading body" {})))
         json-body))))
 

--- a/src/exoscale/compute/api/http.clj
+++ b/src/exoscale/compute/api/http.clj
@@ -84,9 +84,7 @@
 (defn parse-body [response opts]
   (update response
           :body
-          (fn [body]
-            (deref (read-body-with-timeout! body
-                                            (:read-body-timeout opts))))))
+          #(read-body-with-timeout! % (:read-body-timeout opts))))
 
 (defn raw-request!!
   "Send an HTTP request"
@@ -103,7 +101,7 @@
                                        :method method)
                           (= :post method)
                           (assoc :headers {:content-type "application/x-www-form-urlencoded"})))
-        (auspex/chain parse-body)
+        (auspex/chain #(parse-body % opts))
         with-decoded-error-body)))
 
 (defn extract-response

--- a/test/exoscale/compute/api/http_test.clj
+++ b/test/exoscale/compute/api/http_test.clj
@@ -5,6 +5,7 @@
             [exoscale.compute.api.utils-test :as utils]
             [cheshire.core :as json]
             [spy.core :as spy]
+            [clojure.java.io :as io]
             [spy.assert :as assert])
   (:import (java.io InputStream)))
 
@@ -234,8 +235,9 @@
 
 (deftest body-read-test
   (is (= []
-         (http/read-body-with-timeout! (clojure.java.io/input-stream (.getBytes "[]"))
-                                       10)))
+         (http/read-body-with-timeout! (io/input-stream (.getBytes "[]"))
+                                       10
+                                       @http/default-read-body-executor)))
   (let [closed? (atom false)
         input-stream (proxy [InputStream] []
                        (read ^int
@@ -245,5 +247,6 @@
                        (close [] (reset! closed? true)))]
     (is (thrown? clojure.lang.ExceptionInfo
                  (http/read-body-with-timeout! input-stream
-                                               100)))
+                                               100
+                                               @http/default-read-body-executor)))
     (is @closed? "make sure it was auto-closed")))


### PR DESCRIPTION
We have a case where for some unknown reason as of now (likely a network glitch in that case) reading the body gets stuck forever at https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/master/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java#L352
This causes the client to be unresponsive after a while.

A nicer way to do this might be to implement a custom BodySubscriber that is timeout aware (that would be less costly in threads since the expiration process can poll at intervals for all subscribers and emit onError upon expiration) or better have the jdk http client properly support socket read timeout, but for now we'll do that **naive** fix given the urgency.

The approach taken here is just to read body inputstream in a separate thread and try to deref it's value with a timeout in the callback, if we get an expiration we trigger a .close manually on the stream, which would propagate the disposal of linked resources and if it completes in time we just let the inputstream be disposed of by the http client itself.

